### PR TITLE
bump event-dispatcher to 2.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "stil/curl-easy",
     "require": {
-        "symfony/event-dispatcher": "2.1.*"
+        "symfony/event-dispatcher": "2.2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
symfony event-dispatcher version from 2.1.x to 2.2.x
