### PR TITLE
Support symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "stil/curl-easy",
     "require": {
-        "symfony/event-dispatcher": "2.2.*"
+        "symfony/event-dispatcher": ">=2.2,<3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Small fix that changes allowed versions of symfony/event-dispatcher
