### PR TITLE
Add getHeaders()

### DIFF
--- a/src/cURL/Response.php
+++ b/src/cURL/Response.php
@@ -52,7 +52,7 @@ class Response
     /**
      * Returns Headers of request
      * 
-     * @return Array
+     * @return Array Headers
      */
     public function getHeaders()
     {


### PR DESCRIPTION
i needed to have access to the HEADERS returned by request , so i created this small function.

Example:

``` php
include "vendor/autoload.php";

$queue = new \cURL\RequestsQueue;


$queue->getDefaultOptions()
    ->set(CURLOPT_TIMEOUT, 15)
    ->set(CURLOPT_HEADER, 1) // <--------- IMPORTANT, you MUST SET THIS
    ->set(CURLOPT_RETURNTRANSFER, true);


$queue->addListener('complete', function (\cURL\Event $event) {
    $response = $event->response;
    print_r($response->getHeaders()); // <------- Headers
    echo "\n==============\n";
    echo $response->getContent(); // <------- Content
});

$request = new \cURL\Request('http://192.168.1.1/test.php?sleep=2');
$queue->attach($request);

// Execute queue$queue->send();
```

results:

``` php
Array
(
    [Date] => Thu, 03 Oct 2013 09:40:51 GMT
    [Server] => Apache
    [Content-Length] => 26
    [Connection] => close
    [Content-Type] => text/html; charset=UTF-8
)
==============
<html>....</html>
```

you must set CURLOPT_HEADER & CURLOPT_RETURNTRANSFER, i think that it will be better if easy-curl do it automatically when there is a call for "getHeaders" but i don't know how to do this.
