### PR TITLE
Explicit close() functions

### DIFF
--- a/src/cURL/Request.php
+++ b/src/cURL/Request.php
@@ -45,9 +45,28 @@ class Request extends EventDispatcher implements RequestInterface
     public function __destruct()
     {
         if (isset($this->ch)) {
-            curl_close($this->ch);
+            $this->close();
         }
     }
+	
+	/**
+     * Closes cURL resource and frees the memory.
+     * Explicitly unsets the handle and closes
+	 * the RequestsQueus as well
+     *
+     * @return void
+     */
+	public function close()
+	{
+		curl_close($this->ch);
+		unset($this->ch);
+		
+		if (isset($this->queue))
+		{
+			$this->queue->close();
+			unset($this->queue);
+		}
+	}
     
     /**
      * Get the cURL\Options instance

--- a/src/cURL/RequestsQueue.php
+++ b/src/cURL/RequestsQueue.php
@@ -49,9 +49,20 @@ class RequestsQueue extends EventDispatcher implements RequestsQueueInterface, C
     public function __destruct()
     {
         if (isset($this->mh)) {
-            curl_multi_close($this->mh);
+            $this->close();
         }
     }
+	
+	/**
+	 * Close the curl_multi handler and unset
+	 * 
+	 * @return void
+	 */
+	public function close()
+	{
+		curl_multi_close($this->mh);
+		unset($this->mh);
+	}
     
     /**
      * Returns cURL\Options object with default request's options


### PR DESCRIPTION
I ran into some issues with PHP not releasing memory correctly, so I created an explicit close() function that closes and unsets the handle for both cURL/Request and cURL/RequestsQueue
