### PR TITLE
Upgrade symfony/event-dispatcher to ^5.0, ^6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# 2.0.0
+
+#### Changes
+
+* Requires PHP >= 7.2
+* Static signature typing to the level of PHP 7.2
+* Nothing else changed
+
+#### New features/improvements
+
+* Works with `symfony/event-dispatcher` `^5.0`, `^6.0`
+* Improved static typing and phpdoc annotations
+
+#### Dev
+
+* Upgraded `phpunit/phpunit`

--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,23 @@
 {
-    "name": "stil/curl-easy",
-    "description": "cURL wrapper for PHP. Supports parallel and non-blocking requests. For high speed crawling, see stil/curl-robot.",
-    "license": "MIT",
-    "require": {
-        "symfony/event-dispatcher": "^3.2"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^6.1"
-    },
-    "autoload": {
-        "psr-4": {
-            "cURL\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "cURL\\Tests\\": "tests/"
-        }
+  "name": "stil/curl-easy",
+  "description": "cURL wrapper for PHP. Supports parallel and non-blocking requests. For high speed crawling, see stil/curl-robot.",
+  "license": "MIT",
+  "require": {
+    "symfony/event-dispatcher": "^5.0",
+    "ext-curl": "*",
+    "ext-json": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "cURL\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "cURL\\Tests\\": "tests/"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,15 @@
 {
   "name": "stil/curl-easy",
+  "version": "2.0.0",
   "description": "cURL wrapper for PHP. Supports parallel and non-blocking requests. For high speed crawling, see stil/curl-robot.",
   "license": "MIT",
   "require": {
-    "symfony/event-dispatcher": "^5.0",
-    "ext-curl": "*",
-    "ext-json": "*"
+    "symfony/event-dispatcher": "^5.0 || ^6.0",
+    "ext-curl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^9.5",
+    "ext-json": "*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -14,7 +14,7 @@ class Collection
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->data;
     }
@@ -26,7 +26,7 @@ class Collection
      * @param mixed $value Value
      * @return self
      */
-    public function set($key, $value = null)
+    public function set($key, $value = null): self
     {
         if (is_array($key)) {
             foreach ($key as $k => $v) {
@@ -44,7 +44,7 @@ class Collection
      * @param mixed $key Key
      * @return bool    TRUE if exists, FALSE otherwise
      */
-    public function has($key)
+    public function has($key): bool
     {
         return isset($this->data[$key]);
     }
@@ -71,7 +71,7 @@ class Collection
      * @param mixed $key Key to remove
      * @return self
      */
-    public function remove($key)
+    public function remove($key): self
     {
         unset($this->data[$key]);
         return $this;

--- a/src/ConstantsTable.php
+++ b/src/ConstantsTable.php
@@ -5,14 +5,14 @@ namespace cURL;
 class ConstantsTable
 {
     /**
-     * @var int[] Array of cURL constants required for intelligent setters
+     * @var array<string,int> Array of cURL constants required for intelligent setters
      */
     protected static $curlConstantsTable = array();
 
     /**
      * @return array
      */
-    public static function loadCurlConstantsTable()
+    public static function loadCurlConstantsTable(): array
     {
         if (empty(self::$curlConstantsTable)) {
             $constants = get_defined_constants(true);
@@ -32,7 +32,7 @@ class ConstantsTable
      * @return int
      * @throws Exception
      */
-    public static function findNumericValue($const)
+    public static function findNumericValue(string $const): int
     {
         $table = self::loadCurlConstantsTable();
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -2,7 +2,7 @@
 
 namespace cURL;
 
-use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Contracts\EventDispatcher\Event as SymfonyEvent;
 
 class Event extends SymfonyEvent
 {

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,39 +1,271 @@
 <?php
 
-namespace cURL;
-
-class Options extends Collection
-{
-    /**
-     * Applies options to Request object
-     *
-     * @param Request $request
-     * @return self
-     */
-    public function applyTo(Request $request)
-    {
-        if (!empty($this->data)) {
-            curl_setopt_array($request->getHandle(), $this->data);
-        }
-
-        return $this;
-    }
+    namespace cURL;
 
     /**
-     * Intelligent setters
-     *
-     * @param string $name Function name
-     * @param array $args Arguments
-     * @throws Exception Invalid CURLOPT_ constant has been specified
-     * @return self
+     * @method setAutoreferer(mixed $value)
+     * @method setBinarytransfer(mixed $value)
+     * @method setBuffersize(mixed $value)
+     * @method setCainfo(mixed $value)
+     * @method setCapath(mixed $value)
+     * @method setConnecttimeout(mixed $value)
+     * @method setCookie(mixed $value)
+     * @method setCookiefile(mixed $value)
+     * @method setCookiejar(mixed $value)
+     * @method setCookiesession(mixed $value)
+     * @method setCrlf(mixed $value)
+     * @method setCustomrequest(mixed $value)
+     * @method setDnsCacheTimeout(mixed $value)
+     * @method setDnsUseGlobalCache(mixed $value)
+     * @method setEgdsocket(mixed $value)
+     * @method setEncoding(mixed $value)
+     * @method setFailonerror(mixed $value)
+     * @method setFile(mixed $value)
+     * @method setFiletime(mixed $value)
+     * @method setFollowlocation(mixed $value)
+     * @method setForbidReuse(mixed $value)
+     * @method setFreshConnect(mixed $value)
+     * @method setFtpappend(mixed $value)
+     * @method setFtplistonly(mixed $value)
+     * @method setFtpport(mixed $value)
+     * @method setFtpUseEprt(mixed $value)
+     * @method setFtpUseEpsv(mixed $value)
+     * @method setHeader(mixed $value)
+     * @method setHeaderfunction(mixed $value)
+     * @method setHttp200aliases(mixed $value)
+     * @method setHttpget(mixed $value)
+     * @method setHttpheader(mixed $value)
+     * @method setHttpproxytunnel(mixed $value)
+     * @method setHttpVersion(mixed $value)
+     * @method setInfile(mixed $value)
+     * @method setInfilesize(mixed $value)
+     * @method setInterface(mixed $value)
+     * @method setKrb4level(mixed $value)
+     * @method setLowSpeedLimit(mixed $value)
+     * @method setLowSpeedTime(mixed $value)
+     * @method setMaxconnects(mixed $value)
+     * @method setMaxredirs(mixed $value)
+     * @method setNetrc(mixed $value)
+     * @method setNobody(mixed $value)
+     * @method setNoprogress(mixed $value)
+     * @method setNosignal(mixed $value)
+     * @method setPort(mixed $value)
+     * @method setPost(mixed $value)
+     * @method setPostfields(mixed $value)
+     * @method setPostquote(mixed $value)
+     * @method setPrequote(mixed $value)
+     * @method setPrivate(mixed $value)
+     * @method setProgressfunction(mixed $value)
+     * @method setProxy(mixed $value)
+     * @method setProxyport(mixed $value)
+     * @method setProxytype(mixed $value)
+     * @method setProxyuserpwd(mixed $value)
+     * @method setPut(mixed $value)
+     * @method setQuote(mixed $value)
+     * @method setRandomFile(mixed $value)
+     * @method setRange(mixed $value)
+     * @method setReaddata(mixed $value)
+     * @method setReadfunction(mixed $value)
+     * @method setReferer(mixed $value)
+     * @method setResumeFrom(mixed $value)
+     * @method setReturntransfer(mixed $value)
+     * @method setShare(mixed $value)
+     * @method setSslcert(mixed $value)
+     * @method setSslcertpasswd(mixed $value)
+     * @method setSslcerttype(mixed $value)
+     * @method setSslengine(mixed $value)
+     * @method setSslengineDefault(mixed $value)
+     * @method setSslkey(mixed $value)
+     * @method setSslkeypasswd(mixed $value)
+     * @method setSslkeytype(mixed $value)
+     * @method setSslversion(mixed $value)
+     * @method setSslCipherList(mixed $value)
+     * @method setSslVerifyhost(mixed $value)
+     * @method setSslVerifypeer(mixed $value)
+     * @method setStderr(mixed $value)
+     * @method setTelnetoptions(mixed $value)
+     * @method setTimecondition(mixed $value)
+     * @method setTimeout(mixed $value)
+     * @method setTimevalue(mixed $value)
+     * @method setTransfertext(mixed $value)
+     * @method setUnrestrictedAuth(mixed $value)
+     * @method setUpload(mixed $value)
+     * @method setUrl(mixed $value)
+     * @method setUseragent(mixed $value)
+     * @method setUserpwd(mixed $value)
+     * @method setVerbose(mixed $value)
+     * @method setWritefunction(mixed $value)
+     * @method setWriteheader(mixed $value)
+     * @method setHttpauth(mixed $value)
+     * @method setFtpCreateMissingDirs(mixed $value)
+     * @method setProxyauth(mixed $value)
+     * @method setFtpResponseTimeout(mixed $value)
+     * @method setIpresolve(mixed $value)
+     * @method setMaxfilesize(mixed $value)
+     * @method setFtpSsl(mixed $value)
+     * @method setNetrcFile(mixed $value)
+     * @method setTcpNodelay(mixed $value)
+     * @method setFtpsslauth(mixed $value)
+     * @method setFtpAccount(mixed $value)
+     * @method setCookielist(mixed $value)
+     * @method setIgnoreContentLength(mixed $value)
+     * @method setFtpSkipPasvIp(mixed $value)
+     * @method setFtpFilemethod(mixed $value)
+     * @method setConnectOnly(mixed $value)
+     * @method setLocalport(mixed $value)
+     * @method setLocalportrange(mixed $value)
+     * @method setFtpAlternativeToUser(mixed $value)
+     * @method setMaxRecvSpeedLarge(mixed $value)
+     * @method setMaxSendSpeedLarge(mixed $value)
+     * @method setSslSessionidCache(mixed $value)
+     * @method setFtpSslCcc(mixed $value)
+     * @method setSshAuthTypes(mixed $value)
+     * @method setSshPrivateKeyfile(mixed $value)
+     * @method setSshPublicKeyfile(mixed $value)
+     * @method setConnecttimeoutMs(mixed $value)
+     * @method setHttpContentDecoding(mixed $value)
+     * @method setHttpTransferDecoding(mixed $value)
+     * @method setTimeoutMs(mixed $value)
+     * @method setKrblevel(mixed $value)
+     * @method setNewDirectoryPerms(mixed $value)
+     * @method setNewFilePerms(mixed $value)
+     * @method setAppend(mixed $value)
+     * @method setDirlistonly(mixed $value)
+     * @method setUseSsl(mixed $value)
+     * @method setSshHostPublicKeyMd5(mixed $value)
+     * @method setProxyTransferMode(mixed $value)
+     * @method setAddressScope(mixed $value)
+     * @method setCrlfile(mixed $value)
+     * @method setIssuercert(mixed $value)
+     * @method setKeypasswd(mixed $value)
+     * @method setCertinfo(mixed $value)
+     * @method setPassword(mixed $value)
+     * @method setPostredir(mixed $value)
+     * @method setProxypassword(mixed $value)
+     * @method setProxyusername(mixed $value)
+     * @method setUsername(mixed $value)
+     * @method setNoproxy(mixed $value)
+     * @method setProtocols(mixed $value)
+     * @method setRedirProtocols(mixed $value)
+     * @method setSocks5GssapiNec(mixed $value)
+     * @method setSocks5GssapiService(mixed $value)
+     * @method setTftpBlksize(mixed $value)
+     * @method setSshKnownhosts(mixed $value)
+     * @method setFtpUsePret(mixed $value)
+     * @method setMailFrom(mixed $value)
+     * @method setMailRcpt(mixed $value)
+     * @method setRtspClientCseq(mixed $value)
+     * @method setRtspRequest(mixed $value)
+     * @method setRtspServerCseq(mixed $value)
+     * @method setRtspSessionId(mixed $value)
+     * @method setRtspStreamUri(mixed $value)
+     * @method setRtspTransport(mixed $value)
+     * @method setFnmatchFunction(mixed $value)
+     * @method setWildcardmatch(mixed $value)
+     * @method setResolve(mixed $value)
+     * @method setTlsauthPassword(mixed $value)
+     * @method setTlsauthType(mixed $value)
+     * @method setTlsauthUsername(mixed $value)
+     * @method setAcceptEncoding(mixed $value)
+     * @method setTransferEncoding(mixed $value)
+     * @method setGssapiDelegation(mixed $value)
+     * @method setAccepttimeoutMs(mixed $value)
+     * @method setDnsServers(mixed $value)
+     * @method setMailAuth(mixed $value)
+     * @method setSslOptions(mixed $value)
+     * @method setTcpKeepalive(mixed $value)
+     * @method setTcpKeepidle(mixed $value)
+     * @method setTcpKeepintvl(mixed $value)
+     * @method setSaslIr(mixed $value)
+     * @method setDnsInterface(mixed $value)
+     * @method setDnsLocalIp4(mixed $value)
+     * @method setDnsLocalIp6(mixed $value)
+     * @method setXoauth2Bearer(mixed $value)
+     * @method setLoginOptions(mixed $value)
+     * @method setExpect100TimeoutMs(mixed $value)
+     * @method setSslEnableAlpn(mixed $value)
+     * @method setSslEnableNpn(mixed $value)
+     * @method setHeaderopt(mixed $value)
+     * @method setProxyheader(mixed $value)
+     * @method setPinnedpublickey(mixed $value)
+     * @method setUnixSocketPath(mixed $value)
+     * @method setSslVerifystatus(mixed $value)
+     * @method setPathAsIs(mixed $value)
+     * @method setSslFalsestart(mixed $value)
+     * @method setPipewait(mixed $value)
+     * @method setProxyServiceName(mixed $value)
+     * @method setServiceName(mixed $value)
+     * @method setDefaultProtocol(mixed $value)
+     * @method setStreamWeight(mixed $value)
+     * @method setTftpNoOptions(mixed $value)
+     * @method setConnectTo(mixed $value)
+     * @method setTcpFastopen(mixed $value)
+     * @method setKeepSendingOnError(mixed $value)
+     * @method setPreProxy(mixed $value)
+     * @method setProxyCainfo(mixed $value)
+     * @method setProxyCapath(mixed $value)
+     * @method setProxyCrlfile(mixed $value)
+     * @method setProxyKeypasswd(mixed $value)
+     * @method setProxyPinnedpublickey(mixed $value)
+     * @method setProxySslCipherList(mixed $value)
+     * @method setProxySslOptions(mixed $value)
+     * @method setProxySslVerifyhost(mixed $value)
+     * @method setProxySslVerifypeer(mixed $value)
+     * @method setProxySslcert(mixed $value)
+     * @method setProxySslcerttype(mixed $value)
+     * @method setProxySslkey(mixed $value)
+     * @method setProxySslkeytype(mixed $value)
+     * @method setProxySslversion(mixed $value)
+     * @method setProxyTlsauthPassword(mixed $value)
+     * @method setProxyTlsauthType(mixed $value)
+     * @method setProxyTlsauthUsername(mixed $value)
+     * @method setAbstractUnixSocket(mixed $value)
+     * @method setSuppressConnectHeaders(mixed $value)
+     * @method setRequestTarget(mixed $value)
+     * @method setSocks5Auth(mixed $value)
+     * @method setSshCompression(mixed $value)
+     * @method setHappyEyeballsTimeoutMs(mixed $value)
+     * @method setTimevalueLarge(mixed $value)
+     * @method setDnsShuffleAddresses(mixed $value)
+     * @method setHaproxyprotocol(mixed $value)
+     * @method setDisallowUsernameInUrl(mixed $value)
+     * @method setProxyTls13Ciphers(mixed $value)
+     * @method setTls13Ciphers(mixed $value)
+     * @method setHttp09Allowed(mixed $value)
+     * @method setSafeUpload(mixed $value)
      */
-    public function __call($name, $args)
+    class Options extends Collection
     {
-        if (substr($name, 0, 3) == 'set' && isset($args[0])) {
-            $const = strtoupper(substr($name, 3));
-            $numericValue = ConstantsTable::findNumericValue($const);
-            $this->set($numericValue, $args[0]);
+        /**
+         * Applies options to Request object
+         *
+         * @param Request $request
+         * @return self
+         */
+        public function applyTo(Request $request): self
+        {
+            if (!empty($this->data)) {
+                curl_setopt_array($request->getHandle(), $this->data);
+            }
+
+            return $this;
         }
-        return $this;
+
+        /**
+         * Intelligent setters
+         *
+         * @param string $name Function name
+         * @param array $args Arguments
+         * @return self
+         * @throws Exception Invalid CURLOPT_ constant has been specified
+         */
+        public function __call(string $name, array $args): self
+        {
+            if (substr($name, 0, 3) == 'set' && isset($args[0])) {
+                $const = strtoupper(substr($name, 3));
+                $numericValue = ConstantsTable::findNumericValue($const);
+                $this->set($numericValue, $args[0]);
+            }
+            return $this;
+        }
     }
-}

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,147 +1,151 @@
 <?php
+    namespace cURL;
 
-namespace cURL;
+    use CurlHandle;
+    use Symfony\Component\EventDispatcher\EventDispatcher;
 
-use Symfony\Component\EventDispatcher\EventDispatcher;
-
-class Request extends EventDispatcher implements RequestInterface
-{
-    /**
-     * @var resource cURL handler
-     */
-    protected $ch;
-
-    /**
-     * @var RequestsQueue Queue instance when requesting async
-     */
-    protected $queue;
-
-    /**
-     * @var Options Object containing options for current request
-     */
-    protected $options = null;
-
-    /**
-     * Create new cURL handle
-     *
-     * @param string $url The URL to fetch.
-     */
-    public function __construct($url = null)
+    class Request extends EventDispatcher implements RequestInterface
     {
-        if ($url !== null) {
-            $this->getOptions()->set(CURLOPT_URL, $url);
+        /**
+         * @var resource|CurlHandle cURL handler
+         */
+        protected $ch;
+
+        /**
+         * @var RequestsQueue Queue instance when requesting async
+         */
+        protected $queue;
+
+        /**
+         * @var Options Object containing options for current request
+         */
+        protected $options = null;
+
+        /**
+         * Create new cURL handle
+         *
+         * @param string|null $url The URL to fetch.
+         */
+        public function __construct(string $url = null)
+        {
+            parent::__construct();
+            if ($url !== null) {
+                $this->getOptions()->set(CURLOPT_URL, $url);
+            }
+            $this->ch = curl_init();
         }
-        $this->ch = curl_init();
-    }
 
-    /**
-     * Closes cURL resource and frees the memory.
-     * It is neccessary when you make a lot of requests
-     * and you want to avoid fill up the memory.
-     */
-    public function __destruct()
-    {
-        if (isset($this->ch)) {
-            curl_close($this->ch);
+        /**
+         * Closes cURL resource and frees the memory.
+         * It is neccessary when you make a lot of requests
+         * and you want to avoid fill up the memory.
+         */
+        public function __destruct()
+        {
+            if (isset($this->ch)) {
+                curl_close($this->ch);
+            }
+        }
+
+        /**
+         * Get the cURL\Options instance
+         * Creates empty one if does not exist
+         *
+         * @return Options
+         */
+        public function getOptions(): Options
+        {
+            if (!isset($this->options)) {
+                $this->options = new Options();
+            }
+            return $this->options;
+        }
+
+        /**
+         * Sets Options
+         *
+         * @param Options $options Options
+         * @return void
+         */
+        public function setOptions(Options $options): void
+        {
+            $this->options = $options;
+        }
+
+        /**
+         * Returns cURL raw resource
+         *
+         * @return resource|CurlHandle    cURL handle
+         * @noinspection PhpMissingReturnTypeInspection
+         */
+        public function getHandle()
+        {
+            return $this->ch;
+        }
+
+        /**
+         * Get unique id of cURL handle
+         * Useful for debugging or logging.
+         *
+         * @return int
+         */
+        public function getUID(): int
+        {
+            return (int)$this->ch;
+        }
+
+        /**
+         * Perform a cURL session.
+         * Equivalent to curl_exec().
+         * This function should be called after initializing a cURL
+         * session and all the options for the session are set.
+         *
+         * Warning: it doesn't fire 'complete' event.
+         *
+         * @return Response
+         */
+        public function send(): Response
+        {
+            if ($this->options instanceof Options) {
+                $this->options->applyTo($this);
+            }
+            $content = curl_exec($this->ch);
+
+            $response = new Response($this, $content);
+            $errorCode = curl_errno($this->ch);
+            if ($errorCode !== CURLE_OK) {
+                $response->setError(new Error(curl_error($this->ch), $errorCode));
+            }
+            return $response;
+        }
+
+        /**
+         * Creates new RequestsQueue with single Request attached to it
+         * and calls RequestsQueue::socketPerform() method.
+         *
+         * @throws Exception
+         * @see RequestsQueue::socketPerform()
+         */
+        public function socketPerform(): bool
+        {
+            if (!isset($this->queue)) {
+                $this->queue = new RequestsQueue();
+                $this->queue->attach($this);
+            }
+            return $this->queue->socketPerform();
+        }
+
+        /**
+         * Calls socketSelect() on previously created RequestsQueue
+         *
+         * @throws Exception
+         * @see RequestsQueue::socketSelect()
+         */
+        public function socketSelect($timeout = 1): bool
+        {
+            if (!isset($this->queue)) {
+                throw new Exception('You need to call socketPerform() before.');
+            }
+            return $this->queue->socketSelect($timeout);
         }
     }
-
-    /**
-     * Get the cURL\Options instance
-     * Creates empty one if does not exist
-     *
-     * @return Options
-     */
-    public function getOptions()
-    {
-        if (!isset($this->options)) {
-            $this->options = new Options();
-        }
-        return $this->options;
-    }
-
-    /**
-     * Sets Options
-     *
-     * @param Options $options Options
-     * @return void
-     */
-    public function setOptions(Options $options)
-    {
-        $this->options = $options;
-    }
-
-    /**
-     * Returns cURL raw resource
-     *
-     * @return resource    cURL handle
-     */
-    public function getHandle()
-    {
-        return $this->ch;
-    }
-
-    /**
-     * Get unique id of cURL handle
-     * Useful for debugging or logging.
-     *
-     * @return int
-     */
-    public function getUID()
-    {
-        return (int)$this->ch;
-    }
-
-    /**
-     * Perform a cURL session.
-     * Equivalent to curl_exec().
-     * This function should be called after initializing a cURL
-     * session and all the options for the session are set.
-     *
-     * Warning: it doesn't fire 'complete' event.
-     *
-     * @return Response
-     */
-    public function send()
-    {
-        if ($this->options instanceof Options) {
-            $this->options->applyTo($this);
-        }
-        $content = curl_exec($this->ch);
-
-        $response = new Response($this, $content);
-        $errorCode = curl_errno($this->ch);
-        if ($errorCode !== CURLE_OK) {
-            $response->setError(new Error(curl_error($this->ch), $errorCode));
-        }
-        return $response;
-    }
-
-    /**
-     * Creates new RequestsQueue with single Request attached to it
-     * and calls RequestsQueue::socketPerform() method.
-     *
-     * @see RequestsQueue::socketPerform()
-     */
-    public function socketPerform()
-    {
-        if (!isset($this->queue)) {
-            $this->queue = new RequestsQueue();
-            $this->queue->attach($this);
-        }
-        return $this->queue->socketPerform();
-    }
-
-    /**
-     * Calls socketSelect() on previously created RequestsQueue
-     *
-     * @see RequestsQueue::socketSelect()
-     */
-    public function socketSelect($timeout = 1)
-    {
-        if (!isset($this->queue)) {
-            throw new Exception('You need to call socketPerform() before.');
-        }
-        return $this->queue->socketSelect($timeout);
-    }
-}

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace cURL;
+    namespace cURL;
 
-interface RequestInterface
-{
-    public function getOptions();
+    interface RequestInterface
+    {
+        public function getOptions(): Options;
 
-    public function setOptions(Options $options);
+        public function setOptions(Options $options): void;
 
-    public function getUID();
+        public function getUID(): int;
 
-    public function socketPerform();
+        public function socketPerform(): bool;
 
-    public function socketSelect($timeout);
+        public function socketSelect($timeout): bool;
 
-    public function send();
-}
+        public function send(): Response;
+    }

--- a/src/RequestsQueue.php
+++ b/src/RequestsQueue.php
@@ -1,232 +1,239 @@
 <?php
 
-namespace cURL;
+    namespace cURL;
 
-use Symfony\Component\EventDispatcher\EventDispatcher;
+    use Countable;
+    use CurlMultiHandle;
+    use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class RequestsQueue extends EventDispatcher implements RequestsQueueInterface, \Countable
-{
-    /**
-     * @var Options Default options for new Requests attached to RequestsQueue
-     */
-    protected $defaultOptions = null;
-
-    /**
-     * @var resource cURL multi handler
-     */
-    protected $mh;
-
-    /**
-     * @var Request[] Array of requests attached
-     */
-    protected $queue = array();
-
-    /**
-     * @var array Array of requests added to curl multi handle
-     */
-    protected $running = array();
-
-    /**
-     * Initializes curl_multi handler
-     */
-    public function __construct()
+    class RequestsQueue extends EventDispatcher implements RequestsQueueInterface, Countable
     {
-        $this->mh = curl_multi_init();
-    }
+        /**
+         * @var Options Default options for new Requests attached to RequestsQueue
+         */
+        protected $defaultOptions = null;
 
-    /**
-     * Destructor, closes curl_multi handler
-     *
-     * @return void
-     */
-    public function __destruct()
-    {
-        if (isset($this->mh)) {
-            curl_multi_close($this->mh);
+        /**
+         * @var resource|CurlMultiHandle cURL multi handler
+         */
+        protected $mh;
+
+        /**
+         * @var Request[] Array of requests attached
+         */
+        protected $queue = [];
+
+        /**
+         * @var Request[] Array of requests added to curl multi handle
+         */
+        protected $running = [];
+
+        /**
+         * Initializes curl_multi handler
+         */
+        public function __construct()
+        {
+            parent::__construct();
+            $this->mh = curl_multi_init();
         }
-    }
 
-    /**
-     * Returns cURL\Options object with default request's options
-     *
-     * @return Options
-     */
-    public function getDefaultOptions()
-    {
-        if (!isset($this->defaultOptions)) {
-            $this->defaultOptions = new Options();
-        }
-        return $this->defaultOptions;
-    }
-
-    /**
-     * Overrides default options with given Options object
-     *
-     * @param Options $defaultOptions New options
-     * @return void
-     */
-    public function setDefaultOptions(Options $defaultOptions)
-    {
-        $this->defaultOptions = $defaultOptions;
-    }
-
-    /**
-     * Get cURL multi handle
-     *
-     * @return resource
-     */
-    public function getHandle()
-    {
-        return $this->mh;
-    }
-
-    /**
-     * Attach request to queue.
-     *
-     * @param Request $request Request to add
-     * @return self
-     */
-    public function attach(Request $request)
-    {
-        $this->queue[$request->getUID()] = $request;
-        return $this;
-    }
-
-    /**
-     * Detach request from queue.
-     *
-     * @param Request $request Request to remove
-     * @return self
-     */
-    public function detach(Request $request)
-    {
-        unset($this->queue[$request->getUID()]);
-        return $this;
-    }
-
-    /**
-     * Processes handles which are ready and removes them from pool.
-     *
-     * @return int Amount of requests completed
-     */
-    protected function read()
-    {
-        $n = 0;
-        while ($info = curl_multi_info_read($this->mh)) {
-            $n++;
-            $request = $this->queue[(int)$info['handle']];
-            $result = $info['result'];
-
-            curl_multi_remove_handle($this->mh, $request->getHandle());
-            unset($this->running[$request->getUID()]);
-            $this->detach($request);
-
-            $event = new Event();
-            $event->request = $request;
-            $event->response = new Response($request, curl_multi_getcontent($request->getHandle()));
-            if ($result !== CURLE_OK) {
-                $event->response->setError(new Error(curl_error($request->getHandle()), $result));
+        /**
+         * Destructor, closes curl_multi handler
+         *
+         * @return void
+         */
+        public function __destruct()
+        {
+            if (isset($this->mh)) {
+                curl_multi_close($this->mh);
             }
-            $event->queue = $this;
-            $this->dispatch('complete', $event);
-            $request->dispatch('complete', $event);
         }
 
-        return $n;
-    }
-
-    /**
-     * Returns count of handles in queue
-     *
-     * @return int    Handles count
-     */
-    public function count()
-    {
-        return count($this->queue);
-    }
-
-    /**
-     * Executes requests in parallel
-     *
-     * @return void
-     */
-    public function send()
-    {
-        while ($this->socketPerform()) {
-            $this->socketSelect();
-        }
-    }
-
-    /**
-     * Returns requests present in $queue but not in $running
-     *
-     * @return Request[]    Array of requests
-     */
-    protected function getRequestsNotRunning()
-    {
-        $map = $this->queue;
-        foreach ($this->running as $k => $v) unset($map[$k]);
-        return $map;
-    }
-
-    /**
-     * Download available data on socket.
-     *
-     * @throws Exception
-     * @return bool    TRUE when there are any requests on queue, FALSE when finished
-     */
-    public function socketPerform()
-    {
-        if ($this->count() == 0) {
-            throw new Exception('Cannot perform if there are no requests in queue.');
+        /**
+         * Returns cURL\Options object with default request's options
+         *
+         * @return Options
+         */
+        public function getDefaultOptions(): Options
+        {
+            if (!isset($this->defaultOptions)) {
+                $this->defaultOptions = new Options();
+            }
+            return $this->defaultOptions;
         }
 
-        $notRunning = $this->getRequestsNotRunning();
-        do {
-            /**
-             * Apply cURL options to new requests
-             */
-            foreach ($notRunning as $request) {
-                $this->getDefaultOptions()->applyTo($request);
-                $request->getOptions()->applyTo($request);
-                curl_multi_add_handle($this->mh, $request->getHandle());
-                $this->running[$request->getUID()] = $request;
+        /**
+         * Overrides default options with given Options object
+         *
+         * @param Options $defaultOptions New options
+         * @return void
+         */
+        public function setDefaultOptions(Options $defaultOptions): void
+        {
+            $this->defaultOptions = $defaultOptions;
+        }
+
+        /**
+         * Get cURL multi handle
+         *
+         * @return resource|CurlMultiHandle
+         * @noinspection PhpMissingReturnTypeInspection
+         */
+        public function getHandle()
+        {
+            return $this->mh;
+        }
+
+        /**
+         * Attach request to queue.
+         *
+         * @param Request $request Request to add
+         * @return self
+         */
+        public function attach(Request $request): RequestsQueueInterface
+        {
+            $this->queue[$request->getUID()] = $request;
+            return $this;
+        }
+
+        /**
+         * Detach request from queue.
+         *
+         * @param Request $request Request to remove
+         * @return self
+         */
+        public function detach(Request $request): RequestsQueueInterface
+        {
+            unset($this->queue[$request->getUID()]);
+            return $this;
+        }
+
+        /**
+         * Processes handles which are ready and removes them from pool.
+         *
+         * @return int Amount of requests completed
+         */
+        protected function read(): int
+        {
+            $n = 0;
+            while ($info = curl_multi_info_read($this->mh)) {
+                $n++;
+                $request = $this->queue[(int)$info['handle']];
+                $result = $info['result'];
+
+                curl_multi_remove_handle($this->mh, $request->getHandle());
+                unset($this->running[$request->getUID()]);
+                $this->detach($request);
+
+                $event = new Event();
+                $event->request = $request;
+                $event->response = new Response($request, curl_multi_getcontent($request->getHandle()));
+                if ($result !== CURLE_OK) {
+                    $event->response->setError(new Error(curl_error($request->getHandle()), $result));
+                }
+                $event->queue = $this;
+                $this->dispatch($event, 'complete');
+                $request->dispatch($event, 'complete');
             }
 
-            $runningHandles = null;
-            do {
-                // http://curl.haxx.se/libcurl/c/curl_multi_perform.html
-                // If an added handle fails very quickly, it may never be counted as a running_handle.
-                $mrc = curl_multi_exec($this->mh, $runningHandles);
-            } while ($mrc === CURLM_CALL_MULTI_PERFORM);
+            return $n;
+        }
 
-            if ($runningHandles < count($this->running)) {
-                $this->read();
+        /**
+         * Returns count of handles in queue
+         *
+         * @return int    Handles count
+         */
+        public function count(): int
+        {
+            return count($this->queue);
+        }
+
+        /**
+         * Executes requests in parallel
+         *
+         * @return void
+         * @throws Exception
+         */
+        public function send(): void
+        {
+            while ($this->socketPerform()) {
+                $this->socketSelect();
+            }
+        }
+
+        /**
+         * Returns requests present in $queue but not in $running
+         *
+         * @return Request[]    Array of requests
+         */
+        protected function getRequestsNotRunning(): array
+        {
+            $map = $this->queue;
+            foreach ($this->running as $k => $v) {
+                unset($map[$k]);
+            }
+            return $map;
+        }
+
+        /**
+         * Download available data on socket.
+         *
+         * @return bool    TRUE when there are any requests on queue, FALSE when finished
+         * @throws Exception
+         */
+        public function socketPerform(): bool
+        {
+            if ($this->count() == 0) {
+                throw new Exception('Cannot perform if there are no requests in queue.');
             }
 
             $notRunning = $this->getRequestsNotRunning();
-        } while (count($notRunning) > 0);
-        // Why the loop? New requests might be added at runtime on 'complete' event.
-        // So we need to attach them to curl_multi handle immediately.
+            do {
+                /**
+                 * Apply cURL options to new requests
+                 */
+                foreach ($notRunning as $request) {
+                    $this->getDefaultOptions()->applyTo($request);
+                    $request->getOptions()->applyTo($request);
+                    curl_multi_add_handle($this->mh, $request->getHandle());
+                    $this->running[$request->getUID()] = $request;
+                }
 
-        return $this->count() > 0;
-    }
+                $runningHandles = null;
+                do {
+                    // http://curl.haxx.se/libcurl/c/curl_multi_perform.html
+                    // If an added handle fails very quickly, it may never be counted as a running_handle.
+                    $mrc = curl_multi_exec($this->mh, $runningHandles);
+                } while ($mrc === CURLM_CALL_MULTI_PERFORM);
 
-    /**
-     * Waits until activity on socket
-     * On success, returns TRUE. On failure, this function will
-     * return FALSE on a select failure or timeout (from the underlying
-     * select system call)
-     *
-     * @param float|int $timeout Maximum time to wait
-     * @throws Exception
-     * @return bool
-     */
-    public function socketSelect($timeout = 1)
-    {
-        if ($this->count() == 0) {
-            throw new Exception('Cannot select if there are no requests in queue.');
+                if ($runningHandles < count($this->running)) {
+                    $this->read();
+                }
+
+                $notRunning = $this->getRequestsNotRunning();
+            } while (count($notRunning) > 0);
+            // Why the loop? New requests might be added at runtime on 'complete' event.
+            // So we need to attach them to curl_multi handle immediately.
+
+            return $this->count() > 0;
         }
-        return curl_multi_select($this->mh, $timeout) !== -1;
+
+        /**
+         * Waits until activity on socket
+         * On success, returns TRUE. On failure, this function will
+         * return FALSE on a select failure or timeout (from the underlying
+         * select system call)
+         *
+         * @param float|int $timeout Maximum time to wait
+         * @return bool
+         * @throws Exception
+         */
+        public function socketSelect($timeout = 1): bool
+        {
+            if ($this->count() == 0) {
+                throw new Exception('Cannot select if there are no requests in queue.');
+            }
+            return curl_multi_select($this->mh, $timeout) !== -1;
+        }
     }
-}

--- a/src/RequestsQueueInterface.php
+++ b/src/RequestsQueueInterface.php
@@ -4,17 +4,17 @@ namespace cURL;
 
 interface RequestsQueueInterface
 {
-    public function getDefaultOptions();
+    public function getDefaultOptions(): Options;
 
-    public function setDefaultOptions(Options $defaultOptions);
+    public function setDefaultOptions(Options $defaultOptions): void;
 
-    public function attach(Request $request);
+    public function attach(Request $request): self;
 
-    public function detach(Request $request);
+    public function detach(Request $request): self;
 
-    public function send();
+    public function send(): void;
 
-    public function socketPerform();
+    public function socketPerform(): bool;
 
-    public function socketSelect($timeout);
+    public function socketSelect($timeout): bool;
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -2,19 +2,26 @@
 
 namespace cURL;
 
+use CurlHandle;
+
 class Response
 {
+    /** @var resource|CurlHandle */
     protected $ch;
+
+    /** @var Error|null */
     protected $error;
+
+    /** @var string|null */
     protected $content = null;
 
     /**
      * Constructs response
      *
      * @param Request $request Request
-     * @param string $content Content of reponse
+     * @param string|null $content Content of reponse
      */
-    public function __construct(Request $request, $content = null)
+    public function __construct(Request $request, string $content = null)
     {
         $this->ch = $request->getHandle();
 
@@ -29,10 +36,10 @@ class Response
      * Otherwise, returns an associative array with
      * the following elements (which correspond to opt), or FALSE on failure.
      *
-     * @param int $key One of the CURLINFO_* constants
+     * @param int|null $key One of the CURLINFO_* constants
      * @return mixed
      */
-    public function getInfo($key = null)
+    public function getInfo(int $key = null)
     {
         return $key === null ? curl_getinfo($this->ch) : curl_getinfo($this->ch, $key);
     }
@@ -42,7 +49,7 @@ class Response
      *
      * @return string    Content
      */
-    public function getContent()
+    public function getContent(): ?string
     {
         return $this->content;
     }
@@ -63,17 +70,15 @@ class Response
      *
      * @return Error|null
      */
-    public function getError()
+    public function getError(): ?Error
     {
-        return isset($this->error) ? $this->error : null;
+        return $this->error;
     }
 
     /**
-     * Returns the error number for the last cURL operation.
-     *
-     * @return int  Returns the error number or 0 (zero) if no error occurred.
+     * @return bool
      */
-    public function hasError()
+    public function hasError(): bool
     {
         return isset($this->error);
     }

--- a/tests/ConstantsTableTest.php
+++ b/tests/ConstantsTableTest.php
@@ -3,9 +3,13 @@
 namespace cURL\Tests;
 
 use cURL\ConstantsTable;
+use cURL\Exception;
 
 class ConstantsTableTest extends TestCase
 {
+    /**
+     * @throws Exception
+     */
     public function testFindNumericValue()
     {
         $this->assertEquals(CURLOPT_TIMEOUT, ConstantsTable::findNumericValue('TiMEOUT'));

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -18,14 +18,17 @@ class OptionsTest extends TestCase
         $opts = new Options();
         $array = $opts->toArray();
 
-        $this->assertInternalType('array', $array);
+        $this->assertIsArray($array);
         $this->assertEmpty($array);
     }
 
+    /**
+     * @throws Exception
+     */
     protected function assertsForSet(Options $opts)
     {
         $array = $opts->toArray();
-        $this->assertEquals(2, count($array));
+        $this->assertCount(2, $array);
 
         $values = array(
             CURLOPT_TIMEOUT => 123,
@@ -52,6 +55,9 @@ class OptionsTest extends TestCase
         $this->assertInstanceOf('cURL\Exception', $e);
     }
 
+    /**
+     * @throws Exception
+     */
     public function testSingleSet()
     {
         $opts = new Options();
@@ -60,6 +66,9 @@ class OptionsTest extends TestCase
         $this->assertsForSet($opts);
     }
 
+    /**
+     * @throws Exception
+     */
     public function testArraySet()
     {
         $opts = new Options();
@@ -72,6 +81,9 @@ class OptionsTest extends TestCase
         $this->assertsForSet($opts);
     }
 
+    /**
+     * @throws Exception
+     */
     public function testIntelligentSet()
     {
         $opts = new Options();
@@ -80,13 +92,17 @@ class OptionsTest extends TestCase
 
         $e = null;
         try {
-            $opts->setUserAgentt('browser');
+            /** @noinspection PhpUndefinedMethodInspection */
+            $opts->setUserAgentt('something');
         } catch (Exception $e) {
         }
         $this->assertInstanceOf('cURL\Exception', $e);
         $this->assertsForSet($opts);
     }
 
+    /**
+     * @throws Exception
+     */
     public function testFluentSetters()
     {
         $opts = new Options();

--- a/tests/RequestsQueueTest.php
+++ b/tests/RequestsQueueTest.php
@@ -1,205 +1,218 @@
 <?php
 
-namespace cURL\Tests;
+    namespace cURL\Tests;
 
-use cURL;
+    use cURL;
+    use cURL\Exception;
+    use cURL\RequestsQueue;
+    use SplObjectStorage;
 
-class RequestsQueueTest extends TestCase
-{
-    /**
-     * Test run queue without any requests
-     */
-    public function testSendNoRequests()
+    class RequestsQueueTest extends TestCase
     {
-        $bool = false;
-        try {
-            $q = new cURL\RequestsQueue();
-            $q->send();
-        } catch (cURL\Exception $ex) {
-            $bool = true;
-        }
-        $this->assertTrue($bool);
-    }
-
-    /**
-     * Test setDefaultOptions() and getDefaultOptions()
-     */
-    public function testOptions()
-    {
-        $q = new cURL\RequestsQueue();
-        $opts = $q->getDefaultOptions();
-        $this->assertInstanceOf('cURL\Options', $opts);
-        $this->assertEmpty($opts->toArray());
-
-        $opts = new cURL\Options();
-        $opts->set(CURLOPT_URL, 'http://example-1/');
-        $opts->set(CURLOPT_USERAGENT, 'browser');
-        $q->setDefaultOptions($opts);
-        $this->assertEquals($opts, $q->getDefaultOptions());
-    }
-
-    /**
-     * Returns RequestsQueue for tests
-     *
-     * @return cURL\RequestsQueue    Queue for tests
-     */
-    protected function prepareTestQueue()
-    {
-        $test = $this;
-        $queue = new cURL\RequestsQueue();
-        $queue->getDefaultOptions()
-            ->set(CURLOPT_RETURNTRANSFER, true)
-            ->set(CURLOPT_ENCODING, '');
-        $queue->addListener(
-            'complete',
-            function (cURL\Event $event) use ($test) {
-                $test->validateSuccesfulResponse($event->response, $event->request->_param);
+        /**
+         * Test run queue without any requests
+         */
+        public function testSendNoRequests()
+        {
+            $bool = false;
+            try {
+                $q = new RequestsQueue();
+                $q->send();
+            } catch (cURL\Exception $ex) {
+                $bool = true;
             }
-        );
-
-        for ($i = 0; $i < 5; $i++) {
-            $request = new cURL\Request();
-            $request->_param = $i;
-            $request->getOptions()->set(CURLOPT_URL, $this->createRequestUrl($i));
-            $queue->attach($request);
+            $this->assertTrue($bool);
         }
 
-        $this->assertEquals(5, $queue->count());
-        $this->assertEquals(5, count($queue));
+        /**
+         * Test setDefaultOptions() and getDefaultOptions()
+         */
+        public function testOptions()
+        {
+            $q = new RequestsQueue();
+            $opts = $q->getDefaultOptions();
+            $this->assertInstanceOf('cURL\Options', $opts);
+            $this->assertEmpty($opts->toArray());
 
-        return $queue;
-    }
-
-    /**
-     * Test request synchronous
-     */
-    public function testQueueSynchronous()
-    {
-        $queue = $this->prepareTestQueue();
-        $queue->send();
-    }
-
-    /**
-     * Test request asynchronous
-     */
-    public function testQueueAsynchronous()
-    {
-        $queue = $this->prepareTestQueue();
-
-        while ($queue->socketPerform()) {
-            $queue->socketSelect();
+            $opts = new cURL\Options();
+            $opts->set(CURLOPT_URL, 'http://example-1/');
+            $opts->set(CURLOPT_USERAGENT, 'browser');
+            $q->setDefaultOptions($opts);
+            $this->assertEquals($opts, $q->getDefaultOptions());
         }
 
-        $e = null;
-        try {
-            $queue->socketPerform();
-        } catch (cURL\Exception $e) {
-        }
+        /**
+         * Returns RequestsQueue for tests
+         *
+         * @return RequestsQueue    Queue for tests
+         */
+        protected function prepareTestQueue(): RequestsQueue
+        {
+            $test = $this;
+            $queue = new RequestsQueue();
+            $queue->getDefaultOptions()
+                ->set(CURLOPT_RETURNTRANSFER, true)
+                ->set(CURLOPT_ENCODING, '');
 
-        $this->assertInstanceOf('cURL\Exception', $e);
-    }
+            $s = new SplObjectStorage();
 
-    /**
-     * Test requests attaching on run time
-     */
-    public function testRepeatOnRuntime()
-    {
-        $n = 0;
-        $queue = $this->prepareTestQueue();
-        $queue->addListener(
-            'complete',
-            function (cURL\Event $event) use (&$n) {
-                $n++;
-                $request = $event->request;
-                $queue = $event->queue;
-                if (!isset($request->repeat)) {
-                    $request->repeat = true;
-                    $queue->attach($request);
+            $queue->addListener(
+                'complete',
+                function (cURL\Event $event) use ($test, $s) {
+                    $test->validateSuccesfulResponse($event->response, $s[$event->request]);
                 }
-            }
-        );
-        $queue->send();
-        $this->assertEquals(10, $n);
-    }
+            );
 
-    /**
-     * Test requests attaching on run time
-     */
-    public function testAttachNewOnRuntime()
-    {
-        $total = 10;
-        $test = $this;
-        $queue = new cURL\RequestsQueue();
-        $queue->getDefaultOptions()
-            ->set(CURLOPT_RETURNTRANSFER, true)
-            ->set(CURLOPT_ENCODING, '');
-
-
-        $n = 0;
-        $attachNew = function () use ($queue, &$n, $total) {
-            if ($n < $total) {
-                $n++;
+            for ($i = 0; $i < 5; $i++) {
                 $request = new cURL\Request();
-                $request->_param = $n;
-                $request->getOptions()->set(CURLOPT_URL, $this->createRequestUrl($n));
+                $s[$request] = $i;
+                $request->getOptions()->set(CURLOPT_URL, $this->createRequestUrl($i));
                 $queue->attach($request);
             }
-        };
 
-        $attachNew();
-        $queue->addListener(
-            'complete',
-            function (cURL\Event $event) use (&$requests, $test, $attachNew) {
-                $test->validateSuccesfulResponse($event->response, $event->request->_param);
-                $attachNew();
+            $this->assertEquals(5, $queue->count());
+            $this->assertCount(5, $queue);
+
+            return $queue;
+        }
+
+        /**
+         * Test request synchronous
+         * @throws Exception
+         */
+        public function testQueueSynchronous()
+        {
+            $queue = $this->prepareTestQueue();
+            $queue->send();
+        }
+
+        /**
+         * Test request asynchronous
+         * @throws Exception
+         */
+        public function testQueueAsynchronous()
+        {
+            $queue = $this->prepareTestQueue();
+
+            while ($queue->socketPerform()) {
+                $queue->socketSelect();
             }
-        );
-        $queue->send();
-        $this->assertEquals($total, $n);
-    }
 
-    /**
-     * Tests whether 'complete' event on individual Request has been fired
-     * when using RequestsQueue
-     */
-    public function testRequestCompleteEvent()
-    {
-        $eventFired = 0;
-
-        $req = new cURL\Request();
-        $req->getOptions()
-            ->set(CURLOPT_URL, $this->createRequestUrl())
-            ->set(CURLOPT_RETURNTRANSFER, true);
-        $req->addListener(
-            'complete',
-            function ($event) use (&$eventFired) {
-                $this->validateSuccesfulResponse($event->response);
-                $eventFired++;
+            $e = null;
+            try {
+                $queue->socketPerform();
+            } catch (cURL\Exception $e) {
             }
-        );
 
-        $queue = new cURL\RequestsQueue();
-        $queue->attach($req);
-        $queue->send();
+            $this->assertInstanceOf('cURL\Exception', $e);
+        }
 
-        $this->assertEquals(1, $eventFired);
+        /**
+         * Test requests attaching on run time
+         * @throws Exception
+         */
+        public function testRepeatOnRuntime()
+        {
+            $n = 0;
+            $queue = $this->prepareTestQueue();
+            $queue->addListener(
+                'complete',
+                function (cURL\Event $event) use (&$n) {
+                    $n++;
+                    $request = $event->request;
+                    $queue = $event->queue;
+                    if (!isset($request->repeat)) {
+                        $request->repeat = true;
+                        $queue->attach($request);
+                    }
+                }
+            );
+            $queue->send();
+            $this->assertEquals(10, $n);
+        }
+
+        /**
+         * Test requests attaching on run time
+         * @throws Exception
+         */
+        public function testAttachNewOnRuntime()
+        {
+            $total = 10;
+            $test = $this;
+            $queue = new RequestsQueue();
+            $queue->getDefaultOptions()
+                ->set(CURLOPT_RETURNTRANSFER, true)
+                ->set(CURLOPT_ENCODING, '');
+
+            $s = new SplObjectStorage();
+
+            $n = 0;
+            $attachNew = function () use ($queue, &$n, $total, $s) {
+                if ($n < $total) {
+                    $n++;
+                    $request = new cURL\Request();
+                    $s[$request] = $n;
+                    $request->getOptions()->set(CURLOPT_URL, $this->createRequestUrl($n));
+                    $queue->attach($request);
+                }
+            };
+
+            $attachNew();
+            $queue->addListener(
+                'complete',
+                function (cURL\Event $event) use (&$requests, $test, $attachNew, $s) {
+                    $test->validateSuccesfulResponse($event->response, $s[$event->request]);
+                    $attachNew();
+                }
+            );
+            $queue->send();
+            $this->assertEquals($total, $n);
+        }
+
+        /**
+         * Tests whether 'complete' event on individual Request has been fired
+         * when using RequestsQueue
+         * @throws Exception
+         */
+        public function testRequestCompleteEvent()
+        {
+            $eventFired = 0;
+
+            $req = new cURL\Request();
+            $req->getOptions()
+                ->set(CURLOPT_URL, $this->createRequestUrl())
+                ->set(CURLOPT_RETURNTRANSFER, true);
+            $req->addListener(
+                'complete',
+                function ($event) use (&$eventFired) {
+                    $this->validateSuccesfulResponse($event->response);
+                    $eventFired++;
+                }
+            );
+
+            $queue = new RequestsQueue();
+            $queue->attach($req);
+            $queue->send();
+
+            $this->assertEquals(1, $eventFired);
+        }
+
+        /**
+         * Requests which fail very quickly might cause infinite loop and return no response.
+         * http://curl.haxx.se/libcurl/c/curl_multi_perform.html
+         * "If an added handle fails very quickly, it may never be counted as a running_handle."
+         * This test ensures that it won't loop and will return properly error code.
+         * @throws Exception
+         */
+        public function testErrorCode()
+        {
+            $request = new cURL\Request('');
+            $request->addListener('complete', function (cURL\Event $e) {
+                $this->assertEquals(3, $e->response->getError()->getCode());
+            });
+
+            $queue = new RequestsQueue();
+            $queue->attach($request);
+            $queue->send();
+        }
     }
-
-    /**
-     * Requests which fail very quickly might cause infinite loop and return no response.
-     * http://curl.haxx.se/libcurl/c/curl_multi_perform.html
-     * "If an added handle fails very quickly, it may never be counted as a running_handle."
-     * This test ensures that it won't loop and will return properly error code.
-     */
-    public function testErrorCode()
-    {
-        $request = new cURL\Request('');
-        $request->addListener('complete', function (cURL\Event $e) {
-            $this->assertEquals('<url> malformed', $e->response->getError()->getMessage());
-        });
-
-        $queue = new cURL\RequestsQueue();
-        $queue->attach($request);
-        $queue->send();
-    }
-}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,38 +1,38 @@
 <?php
 
-namespace cURL\Tests;
+    namespace cURL\Tests;
 
-use cURL\Response;
-use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+    use cURL\Response;
+    use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
-abstract class TestCase extends PHPUnitTestCase
-{
-    protected $okTestUrl = 'https://httpbin.org/get';
-    protected $timeoutTestUrl = 'https://httpbin.org/delay/10';
-
-    public function createRequestUrl($param = 'ok')
+    abstract class TestCase extends PHPUnitTestCase
     {
-        return $this->okTestUrl . '?' . http_build_query(array('curl-easy' => $param));
-    }
+        protected $okTestUrl = 'https://httpbin.org/get';
+        protected $timeoutTestUrl = 'https://httpbin.org/delay/10';
 
-    public function validateSuccesfulResponse(Response $response, $param = 'ok')
-    {
-        $content = $response->getContent();
-        $data = json_decode($content, true);
-        $this->assertInternalType('array', $data);
-        $info = $response->getInfo();
-        $this->assertInternalType('array', $info);
-        $this->assertEquals(200, $info['http_code']);
-        $this->assertEquals($param, $data['args']['curl-easy']);
-        $this->assertEquals(200, $response->getInfo(CURLINFO_HTTP_CODE));
-        $this->assertFalse($response->hasError());
-    }
+        public function createRequestUrl($param = 'ok'): string
+        {
+            return $this->okTestUrl . '?' . http_build_query(['curl-easy' => $param]);
+        }
 
-    public function validateTimeoutedResponse(Response $response)
-    {
-        $this->assertEmpty($response->getContent());
-        $this->assertTrue($response->hasError());
-        $this->assertEquals(CURLE_OPERATION_TIMEOUTED, $response->getError()->getCode());
-        $this->assertNotEmpty($response->getError()->getMessage());
+        public function validateSuccesfulResponse(Response $response, $param = 'ok')
+        {
+            $content = $response->getContent();
+            $data = json_decode($content, true);
+            $this->assertIsArray($data);
+            $info = $response->getInfo();
+            $this->assertIsArray($info);
+            $this->assertEquals(200, $info['http_code']);
+            $this->assertEquals($param, $data['args']['curl-easy']);
+            $this->assertEquals(200, $response->getInfo(CURLINFO_HTTP_CODE));
+            $this->assertFalse($response->hasError());
+        }
+
+        public function validateTimeoutedResponse(Response $response)
+        {
+            $this->assertEmpty($response->getContent());
+            $this->assertTrue($response->hasError());
+            $this->assertEquals(CURLE_OPERATION_TIMEOUTED, $response->getError()->getCode());
+            $this->assertNotEmpty($response->getError()->getMessage());
+        }
     }
-}

--- a/tools/phpdoc.php
+++ b/tools/phpdoc.php
@@ -1,0 +1,28 @@
+<?php
+    $constants = get_defined_constants(true);
+    $camelCasedConstants = [];
+    foreach ($constants['curl'] as $key => $value) {
+        if (strpos($key, 'CURLOPT_') === 0) {
+            $key = substr($key, 8);
+            $camelCase = implode(
+                '',
+                array_map(
+                    function (string $keyFrag) {
+                        return strtoupper($keyFrag[0]) . strtolower(substr($keyFrag, 1));
+                    },
+                    preg_split('`_+`', $key)
+                )
+            );
+            $camelCasedConstants[] = $camelCase;
+        }
+    }
+    echo implode(
+        "\n",
+        array_map(
+            function(string $constant): string {
+                return "     * @method set$constant(mixed \$value)";
+            },
+            $camelCasedConstants
+        )
+    );
+    echo "\n";


### PR DESCRIPTION
# 2.0.0

#### Changes

* Requires PHP >= 7.2
* Static signature typing to the level of PHP 7.2
* Nothing else changed

#### New features/improvements

* Works with `symfony/event-dispatcher` `^5.0`, `^6.0`
* Improved static typing and phpdoc annotations

#### Dev

* Upgraded `phpunit/phpunit`